### PR TITLE
Add manifest.json and post-install.txt for Hochwarth component bundle

### DIFF
--- a/hochwarth/component-bundle/0.0/manifest.json
+++ b/hochwarth/component-bundle/0.0/manifest.json
@@ -1,0 +1,11 @@
+{
+    "bundles": {
+        "Hochwarth\\ComponentBundleSymfony": [
+            "all"
+        ]
+    },
+    "copy-from-recipe": {
+        "src/css/": "assets/css/"
+    },
+    
+}

--- a/hochwarth/component-bundle/0.0/post-install.txt
+++ b/hochwarth/component-bundle/0.0/post-install.txt
@@ -1,0 +1,6 @@
+* style.css wurde in den Ordner /assets/css/ kopiert. Binde diese Datei ein
+  und verwende die Dokumentation unter https://TODO für Hilfe.
+
+  Bei weiteren Fragen melde dich bei
+  - Sven Nolting <nolting@hochwarth-it.de> (Komponentenentwicklung/-implementierung)
+  - Madeline Egert <egert@hochwarth-it.de> (Design und Konzeption)


### PR DESCRIPTION
Include configuration for the Hochwarth component bundle and instructions for integrating the style.css file.